### PR TITLE
Able to parse from document (markdown/html)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -82,6 +82,25 @@ After a post is successfully created, Tumblr will return the newly created post'
 
 The `post` item that's returned will consist of an ID. If you would like to save this to your database, please make sure the field type is a string (this has caused me grief in the past)
 
+Tumblr gem will transform documents preceded by a YAML frontmatter block http://www.yaml.org/.
+
+YAML frontmatter beings with `---` on a single line, followed by YAML, ending with another `---` on a single line, e.g.
+
+  ---
+  type: regular
+  title: "This is my title"
+  date: 2011-09-15 23:00
+  state: draft
+  tags: Ruby, Tumblr
+  ---
+  "And the body goes here"
+
+All YAML parameters are taken from the Tumblr API: http://www.tumblr.com/docs/api
+
+and to create the post just pass the `filepath` alongside the `user` object:
+
+  post = Tumblr::Post.create(user, filepath)
+
 == Updating posts
 
 Updating posts is a lot like creating posts. The only thing you have to do is provide the id of the post you wish to edit (the parameters +type+, +private+ and +format+ are ignored and can be omitted.):

--- a/lib/tumblr/post.rb
+++ b/lib/tumblr/post.rb
@@ -105,7 +105,17 @@ class Tumblr
     
     # extracts options from the arguments, converts a user object to :email and :password params and fixes the :post_id/'post-id' issue.
     def self.process_options(*args)
-      options = args.last.is_a?(Hash) ?  args.pop : {}
+      options = {}
+      if args.last.is_a?(Hash)
+        options.merge(args.pop)
+      elsif args.last.is_a?(String) and File.file? args.last
+        doc = IO.read(args.pop)
+        if doc =~ /^(\s*---(.*)---\s*)/m
+          options = YAML.load(Regexp.last_match[2].strip)
+          options[:body] = doc.sub(Regexp.last_match[1],'').strip
+        end
+      end
+      
 
       if((user = args.first).is_a?(Tumblr::User))        
         options = options.merge(


### PR DESCRIPTION
Hi! It will be nice when creating a post, user are able to parse it from file (markdown/html) containing YAML frontmatter block, and simply passing the filepath as a second argument.

example: Tumblr::Post.create(user, filepath)
